### PR TITLE
Add python-mako to Dockerfile.mxe packages

### DIFF
--- a/Dockerfile.mxe
+++ b/Dockerfile.mxe
@@ -10,7 +10,7 @@ RUN \
         g++ g++-multilib gettext git gperf intltool iputils-ping libc6-dev-i386 \
         libffi-dev libgdk-pixbuf2.0-dev libltdl-dev libssl-dev libtool-bin \
         libxml-parser-perl lzip make nano openssl p7zip-full patch perl \
-        pkg-config python ruby scons sed unzip wget xz-utils && \
+        pkg-config python python-mako ruby scons sed unzip wget xz-utils && \
     apt -y autoremove && \
     apt -y autoclean && \
     apt -y clean && \


### PR DESCRIPTION
Upstream mxe seems to require this now to build mesa.

Fixes #4 